### PR TITLE
Fix data type issues in update_stations.py

### DIFF
--- a/workflows/update_stations.py
+++ b/workflows/update_stations.py
@@ -16,6 +16,7 @@ import sys
 import typing
 
 import fuzzysearch
+import numpy as np
 import pandas as pd
 
 logging.basicConfig(level=logging.INFO)
@@ -24,6 +25,116 @@ logger = logging.getLogger("HathiTrust")
 STATION_NAMES_MAX_LEVENSHTEIN_DISTANCE = 4
 
 WORK_DIR = pathlib.Path("../data")
+
+RAMM_STATION_COLUMN_TYPES = {
+    "Station": "object",
+    "Sediment sample": "object",
+    "Latitude Degrees": "int64",
+    "Latitude Minutes": "int64",
+    "Latitude Seconds": "int64",
+    "North/South": "object",
+    "Longitude Degrees": "int64",
+    "Longitude Minutes": "int64",
+    "Longitude Seconds": "int64",
+    "East/West": "object",
+    "Decimal Longitude": "float64",
+    "Decimal Latitude": "float64",
+    "Location": "object",
+    "FAOarea": "int64",
+    "Water body": "object",
+    "Sea Area": "object",
+    "Place": "object",
+    "Date": "object",
+    "Gear": "object",
+    "Depth (fathoms)": "float64",
+    "Bottom water temperature (C)": "float64",
+    "Bottom temp (F)": "float64",
+    "Bottom water depth D (fathoms)": "float64",
+    "Specific Gravity at bottom": "float64",
+    "Surface temp (C)": "float64",
+    "Surface temp (F)": "float64",
+    "Specific Gravity at surface": "float64",
+    "Temp (F) at 10 Fathoms": "float64",
+    "Temp (F) at 20 Fathoms": "float64",
+    "Temp (F) at 25 Fathoms": "float64",
+    "Temp (F) at 30 Fathoms": "float64",
+    "Temp (F) at 40 Fathoms": "float64",
+    "Temp (F) at 50 Fathoms": "float64",
+    "Temp (F) at 60 Fathoms": "float64",
+    "Temp (F) at 70 Fathoms": "float64",
+    "Temp (F) at 75 Fathoms": "float64",
+    "Temp (F) at 80 Fathoms": "float64",
+    "Temp (F) at 90 Fathoms": "float64",
+    "Temp (F) at 100 Fathoms": "float64",
+    "Temp (F) at 110 Fathoms": "float64",
+    "Temp (F) at 120 Fathoms": "float64",
+    "Temp (F) at 125 Fathoms": "float64",
+    "Temp (F) at 130 Fathoms": "float64",
+    "Temp (F) at 140 Fathoms": "float64",
+    "Temp (F) at 150 Fathoms": "float64",
+    "Temp (F) at 160 Fathoms": "float64",
+    "Temp (F) at 170 Fathoms": "float64",
+    "Temp (F) at 175 Fathoms": "float64",
+    "Temp (F) at 180 Fathoms": "float64",
+    "Temp (F) at 190 Fathoms": "float64",
+    "Temp (F) at 200 Fathoms": "float64",
+    "Temp (F) at 225 Fathoms": "float64",
+    "Temp (F) at 250 Fathoms": "float64",
+    "Temp (F) at 275 Fathoms": "float64",
+    "Temp (F) at 300 Fathoms": "float64",
+    "Temp (F) at 400 Fathoms": "float64",
+    "Temp (F) at 500 Fathoms": "float64",
+    "Temp (F) at 600 Fathoms": "float64",
+    "Temp (F) at 700 Fathoms": "float64",
+    "Temp (F) at 800 Fathoms": "float64",
+    "Temp (F) at 900 Fathoms": "float64",
+    "Temp (F) at 1000 Fathoms": "float64",
+    "Temp (F) at 1100 Fathoms": "float64",
+    "Temp (F) at 1200 Fathoms": "float64",
+    "Temp (F) at 1300 Fathoms": "float64",
+    "Temp (F) at 1330 Fathoms": "float64",
+    "Temp (F) at 1400 Fathoms": "float64",
+    "Temp (F) at 1450 Fathoms": "float64",
+    "Temp (F) at 1500 Fathoms": "float64",
+    "Temp (F) at 1530 Fathoms": "float64",
+    "Temp (F) at 1580 Fathoms": "float64",
+    "Temp (F) at 1600 Fathoms": "float64",
+    "Temp (F) at 1650 Fathoms": "float64",
+    "Temp (F) at 1700 Fathoms": "float64",
+    "Temp (F) at 1725 Fathoms": "float64",
+    "Temp (F) at 1730 Fathoms": "float64",
+    "Temp (F) at 1775 Fathoms": "float64",
+    "Temp (F) at 1780 Fathoms": "float64",
+    "Temp (F) at 1800 Fathoms": "float64",
+    "Temp (F) at 1825 Fathoms": "float64",
+    "Temp (F) at 1850 Fathoms": "float64",
+    "Temp (F) at 1900 Fathoms": "float64",
+    "Temp (F) at 1915 Fathoms": "float64",
+    "Temp (F) at 1980 Fathoms": "float64",
+    "Temp (F) at 2000 Fathoms": "float64",
+    "Temp (F) at 2025 Fathoms": "float64",
+    "Temp (F) at 2100 Fathoms": "float64",
+    "Temp (F) at 2125 Fathoms": "float64",
+    "Temp (F) at 2180 Fathoms": "float64",
+    "Temp (F) at 2200 Fathoms": "float64",
+    "Temp (F) at 2225 Fathoms": "float64",
+    "Temp (F) at 2270 Fathoms": "float64",
+    "Temp (F) at 2300 Fathoms": "float64",
+    "Temp (F) at 2325 Fathoms": "float64",
+    "Temp (F) at 2400 Fathoms": "float64",
+    "Temp (F) at 2425 Fathoms": "float64",
+    "Temp (F) at 2400 Fathoms.1": "float64",
+    "Temp (F) at 2500 Fathoms": "float64",
+    "Temp (F) at 2525 Fathoms": "float64",
+    "Temp (F) at 2600 Fathoms": "float64",
+    "Temp (F) at 2625 Fathoms": "float64",
+    "Temp (F) at 2650 Fathoms": "float64",
+    "Temp (F) at 2675 Fathoms": "float64",
+    "Temp (F) at 2700 Fathoms": "float64",
+    "Temp (F) at 2775 Fathoms": "float64",
+    "Temp (F) at 2800 Fathoms": "float64",
+    "Temp (F) at 2900 Fathoms": "float64",
+}
 
 
 def check_gnames_app(app_name: str, min_version: float) -> str:
@@ -76,7 +187,21 @@ def run() -> None:
     gnfinder_version = check_gnames_app("gnfinder", 0.14)
     gnverifier_version = check_gnames_app("gnverifier", 0.3)
 
-    ramm_stations = pd.read_csv(WORK_DIR / "RAMM" / "stations.csv")
+    # Load all columns as string, i.e. dtype="object"
+    ramm_stations = pd.read_csv(WORK_DIR / "RAMM" / "stations.csv", dtype="object")
+    # Fix RAMM stations data types
+    for column in ramm_stations.columns:
+        # Replace all empty strings with np.nan
+        ramm_stations[column].replace(r"^\s*$", np.nan, regex=True, inplace=True)
+
+        # If the target column type is not string, update its type
+        if RAMM_STATION_COLUMN_TYPES[column] != "object":
+            try:
+                ramm_stations[column] = ramm_stations[column].astype(
+                    RAMM_STATION_COLUMN_TYPES[column]
+                )
+            except ValueError as e:
+                sys.exit(f"Error in column {column}: {e}")
 
     hathitrust_stations = pd.read_csv(WORK_DIR / "HathiTrust" / "stations.csv").dropna()
     hathitrust_stations["Range"] = hathitrust_stations["Range"].apply(json.loads)
@@ -228,17 +353,6 @@ def run() -> None:
                             gnverifier_proc.stdout.read()
                         )
 
-    # Append the stations' text to RAMM data
-    hathitrust_stations.set_index("Station", inplace=True)
-    ramm_stations["HathiTrust"] = ramm_stations["Station"].map(
-        hathitrust_stations.to_dict(orient="index")
-    )
-
-    # Append the stations' species to RAMM data
-    ramm_stations["Species"] = ramm_stations["HathiTrust"].apply(
-        lambda r: stations_species.get(r["Text Identifier"] if pd.notna(r) else None)
-    )
-
     # Rename temp columns so they can be aggregated into one column
     fathom_temp_f = ramm_stations.filter(regex="Temp(.*)")
     ramm_stations.drop(columns=fathom_temp_f.columns, inplace=True)
@@ -253,6 +367,17 @@ def run() -> None:
         )
         .to_dict(orient="index")
         .values()
+    )
+
+    # Append the stations' text to RAMM data
+    hathitrust_stations.set_index("Station", inplace=True)
+    ramm_stations["HathiTrust"] = ramm_stations["Station"].map(
+        hathitrust_stations.to_dict(orient="index")
+    )
+
+    # Append the stations' species to RAMM data
+    ramm_stations["Species"] = ramm_stations["HathiTrust"].apply(
+        lambda r: stations_species.get(r["Text Identifier"] if pd.notna(r) else None)
     )
 
     # Save the updated RAMM data


### PR DESCRIPTION
This PR adds a dictionary of the actual data types for `data/RAMM/stations.csv` and uses that to cast the columns after replacing empty string with `nan`.

You can test it by running `python update_stations.py` from the `workflows` folder. If the test changes the data in `data/Oceans1876`, you can drop them.

Resolves #12 