### PR TITLE
Verify species extracted from summary report index with gnverifier

### DIFF
--- a/workflows/get_all_species.py
+++ b/workflows/get_all_species.py
@@ -4,17 +4,22 @@ The index contains a list of all genus, their species, and all the pages they ar
 mentioned in the summary reports.
 """
 import argparse
+import datetime
 import json
 import logging
 import pathlib
 import re
+import subprocess
+import sys
+import threading
 import time
 from enum import Enum
-from typing import List, Optional, Tuple, TypedDict
+from typing import Dict, List, Optional, Tuple, TypedDict, Union
 
 import cv2 as cv
 import numpy as np
 import pytesseract
+from utils import check_gnames_app
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)-8s %(message)s")
 logger = logging.getLogger("Species Extractor")
@@ -24,6 +29,19 @@ parser.add_argument(
     "--debug",
     action="store_true",
     help="Saves processed images in `data/tmp` for visual inspection",
+)
+parser.add_argument(
+    "--process", action="store_true", help="Process the index and extract species"
+)
+parser.add_argument(
+    "--process-text",
+    action="store_true",
+    help="Process the extracted texts stored in index_species.json",
+)
+parser.add_argument(
+    "--verify-species",
+    action="store_true",
+    help="Verify species with missing matches",
 )
 
 DATA_PATH = pathlib.Path("../data/HathiTrust/sec.6 v.2/images/")
@@ -45,6 +63,7 @@ DebugDict = TypedDict(
         "bounding_box": Tuple[int, int, int, int],
         "texts": List[str],
         "message": str,
+        "need_verification": bool,
     },
 )
 
@@ -69,6 +88,47 @@ ProcessedLineDict = TypedDict(
     },
 )
 
+MatchedSpeciesScoreDict = TypedDict(
+    "MatchedSpeciesScoreDict",
+    {
+        "infraSpecificRankScore": int,
+        "fuzzyLessScore": int,
+        "curatedDataScore": int,
+        "authorMatchScore": int,
+        "acceptedNameScore": int,
+        "parsingQualityScore": int,
+    },
+)
+
+MatchedSpeciesDict = TypedDict(
+    "MatchedSpeciesDict",
+    {
+        "dataSourceId": int,
+        "dataSourceTitleShort": str,
+        "curation": str,
+        "recordId": str,
+        "outlink": str,
+        "entryDate": str,
+        "matchedName": str,
+        "matchedCardinality": int,
+        "matchedCanonicalSimple": str,
+        "matchedCanonicalFull": str,
+        "currentRecordId": str,
+        "currentName": str,
+        "currentCardinality": int,
+        "currentCanonicalSimple": str,
+        "currentCanonicalFull": str,
+        "isSynonym": bool,
+        "classificationPath": str,
+        "classificationRanks": str,
+        "classificationIds": str,
+        "editDistance": int,
+        "stemEditDistance": int,
+        "matchType": str,
+        "scoreDetails": MatchedSpeciesScoreDict,
+    },
+)
+
 GenusSynonymDict = TypedDict("GenusSynonymDict", {"genus": str, "debug": DebugDict})
 
 SpeciesDict = TypedDict(
@@ -76,6 +136,7 @@ SpeciesDict = TypedDict(
     {
         "species": str,
         "genus_synonym": Optional[GenusSynonymDict],
+        "matched_species": Optional[str],
         "pages": List[int],
         "debug": DebugDict,
     },
@@ -86,6 +147,7 @@ GenusDict = TypedDict(
     {
         "genus": str,
         "synonym": Optional[str],
+        "matched_species": Optional[str],
         "pages": List[int],
         "species": List[SpeciesDict],
         "debug": DebugDict,
@@ -95,9 +157,12 @@ GenusDict = TypedDict(
 
 class SpeciesProcessor:
     def __init__(self, debug: bool = False):
+        self.gnverifier_version = check_gnames_app("gnverifier", 0.6)
         self.debug = debug
         self.species: List[GenusDict] = []
+        self.species_verified: Dict[str, MatchedSpeciesDict] = {}
         self.unverified_lines: List[DebugDict] = []
+        self.species_verification_threads = []
 
     def process(self):
         start_time = time.time()
@@ -266,13 +331,9 @@ class SpeciesProcessor:
         except Exception as e:
             logger.exception(e)
 
-        with open(OUTPUT_PATH / "all_species.json", "w") as f:
-            json.dump(self.species, f, indent=2)
+        self.save_species(save_errors=True)
 
-        with open(OUTPUT_PATH / "all_species_unverified.json", "w") as f:
-            json.dump(self.unverified_lines, f, indent=2)
-
-        logger.info(f"Process time: {time.time() - start_time}")
+        logger.info(f"Total processing time: {time.time() - start_time}")
 
     @staticmethod
     def get_contour_extremities(
@@ -343,6 +404,7 @@ class SpeciesProcessor:
                 line=idx + 1,
                 bounding_box=(c_x, c_y, c_w, c_h),
                 message="",
+                need_verification=False,
             )
 
             if c_x <= (2 * start_column // 3):
@@ -353,18 +415,14 @@ class SpeciesProcessor:
 
                 # If the contour start x is less than 2/3 of the start column,
                 # it's a genus. 2/3 is a safe value for this purpose.
-                processed_line = self.process_line(
-                    column_denoised[c_y : c_y + c_h, :], LineType.GENUS
-                )
+                extracted_text = self.process_line(column_denoised[c_y : c_y + c_h, :])
+                processed_line = self.process_text(extracted_text, LineType.GENUS)
+
                 debug_info["texts"].append(processed_line["text"])
+                debug_info["message"] = "genus"
+                debug_info["need_verification"] = processed_line["need_verification"]
 
-                if processed_line["need_verification"]:
-                    debug_info["message"] = "genus"
-                    self.unverified_lines.append(debug_info)
-
-                elif processed_line["type"] == LineType.GENUS:
-                    debug_info["message"] = "genus"
-
+                if processed_line["type"] == LineType.GENUS:
                     if current_genus:
                         # Save the previous genus and its species and start a new one.
                         self.species.append(current_genus)
@@ -372,10 +430,20 @@ class SpeciesProcessor:
                     current_genus = GenusDict(
                         genus=processed_line["value"],
                         synonym=processed_line["synonym"],
+                        matched_species=None,
                         pages=processed_line["pages"],
                         species=[],
                         debug=debug_info,
                     )
+
+                    # Start genus verification in a separate thread.
+                    thread = threading.Thread(
+                        target=self.verify_species,
+                        args=(current_genus["genus"], current_genus),
+                    )
+                    thread.start()
+                    self.species_verification_threads.append(thread)
+
                     current_genus_synonym = None
 
                 elif processed_line["type"] == LineType.CONTINUATION:
@@ -401,24 +469,33 @@ class SpeciesProcessor:
                     )
 
                 # Otherwise, it's a species, or continuation of previous genus.
-                processed_line = self.process_line(
-                    column_denoised[c_y : c_y + c_h, :], LineType.SPECIES
-                )
+                extracted_text = self.process_line(column_denoised[c_y : c_y + c_h, :])
+                processed_line = self.process_text(extracted_text, LineType.SPECIES)
+
                 debug_info["texts"].append(processed_line["text"])
                 debug_info["message"] = "species"
+                debug_info["need_verification"] = processed_line["need_verification"]
 
-                if processed_line["need_verification"]:
-                    debug_info["message"] = "species"
-                    self.unverified_lines.append(debug_info)
-
-                elif processed_line["type"] == LineType.SPECIES:
+                if processed_line["type"] == LineType.SPECIES:
                     species = SpeciesDict(
                         species=processed_line["value"],
+                        matched_species=None,
                         pages=processed_line["pages"],
                         genus_synonym=current_genus_synonym,
                         debug=debug_info,
                     )
                     current_genus["species"].append(species)
+
+                    # Start species verification in a separate thread.
+                    thread = threading.Thread(
+                        target=self.verify_species,
+                        args=(
+                            f"{current_genus['genus']} {species['species']}",
+                            species,
+                        ),
+                    )
+                    thread.start()
+                    self.species_verification_threads.append(thread)
 
                 elif processed_line["type"] == LineType.CONTINUATION:
                     if current_genus["species"]:
@@ -454,52 +531,67 @@ class SpeciesProcessor:
                 img_debug,
             )
 
-    def process_line(self, line: np.ndarray, line_type: LineType) -> ProcessedLineDict:
+    def process_line(self, line: np.ndarray) -> str:
         text: str = pytesseract.image_to_string(line, config="--psm 7")
 
         # Clean up the text.
         # Replace em-dashes with hyphens.
         # Remove left and right single quotes.
-        line_cleaned = (
+        return (
             text.strip()
             .replace("\u2014", "-")
             .replace("\u2018", "")
             .replace("\u2019", "")
         )
 
+    def process_text(self, text: str, line_type: LineType) -> ProcessedLineDict:
         processed_line = ProcessedLineDict(
             type=line_type,
             value=None,
             synonym=None,
             pages=[],
-            text=line_cleaned,
+            text=text,
             need_verification=False,
         )
 
-        if not line_cleaned:
+        if not text:
             processed_line["type"] = LineType.ERROR
             return processed_line
 
         # Double-check the given line type by looking at the first character.
         # Genus starts with an uppercase letter,
         # while species starts with a lowercase letter.
-        first_character_verification = (
-            line_cleaned[0].isupper()
-            if line_type == LineType.GENUS
-            else line_cleaned[0].islower()
-        )
+        if line_type == LineType.GENUS:
+            first_char_is_verified = text[0].isupper()
+        elif line_type == LineType.SPECIES:
+            first_char_is_verified = text[0].islower()
+            if not first_char_is_verified and text[0].isupper() and len(text) > 1:
+                # It's possible that the first character was recognized incorrectly
+                # as a different letter in capitalized form.
+                # We can lower it and use gnverifier to see
+                # if it finds a match, either exact or fuzzy.
+                text = text[0].lower() + text[1:]
+                first_char_is_verified = True
+                processed_line["text"] = text
+                processed_line["need_verification"] = True
+        else:
+            raise ValueError(f"Unknown line type: {line_type}")
 
-        if first_character_verification:
+        if first_char_is_verified:
             # Found a genus or species.
             line_matches = re.search(
-                r"(?P<value>[A-Za-z]+)[,.]?\s*(?P<rest>.*)", line_cleaned
+                r"(?P<value>[a-z\u00C0-\u024F]+)[,.]?\s*(?P<rest>.*)",
+                text,
+                re.I,
             )
             if line_matches:
                 processed_line["type"] = line_type
                 processed_line["value"] = line_matches.group("value")
                 rest = line_matches.group("rest")
                 if rest:
-                    rest_matches = re.search(r"\(see (?P<synonym>[A-Za-z]*)\)", rest)
+                    rest_matches = re.search(
+                        r"\(see (?P<synonym>[a-z\u00C0-\u024F]*)\)", rest, re.I
+                    )
                     if rest_matches:
                         processed_line["synonym"] = rest_matches.group("synonym")
 
@@ -507,32 +599,173 @@ class SpeciesProcessor:
 
                 return processed_line
 
-        elif line_cleaned[0].isdigit():
-            # The line is continuation of pages for the previous value.
-            processed_line["type"] = LineType.CONTINUATION
-            processed_line["pages"] = re.findall(r"\d+", line_cleaned)
+        if line_type == LineType.SPECIES and text[0].isupper():
             return processed_line
 
-        elif (
-            line_cleaned[0] == "("
-            and len(line_cleaned) > 1
-            and line_cleaned[1].isupper()
-        ):
+        elif text[0].isdigit():
+            # The line is continuation of pages for the previous value.
+            processed_line["type"] = LineType.CONTINUATION
+            processed_line["pages"] = re.findall(r"\d+", text)
+            return processed_line
+
+        elif text[0] == "(" and len(text) > 1 and text[1].isupper():
             # This might be a synonym for the current genus.
-            # Check for the value in paranthasis.
-            line_matches = re.search(r"\((?P<value>[A-Z][a-z]+)\)", line_cleaned)
+            # Check for the value in parentheses.
+            line_matches = re.search(r"\((?P<value>[A-Z][a-z\u00C0-\u024F]+)\)", text)
             if line_matches:
                 processed_line["type"] = LineType.GENUS_SYNONYM
                 processed_line["value"] = line_matches.group("value")
                 return processed_line
 
-        elif line_cleaned[0].isalpha():
-            processed_line["type"] = line_type
-            processed_line["need_verification"] = True
-            return processed_line
-
         processed_line["type"] = LineType.ERROR
         return processed_line
+
+    def retry_text_processing(self):
+        self.load_species()
+
+        for genus in self.species:
+            debug_info: DebugDict = genus["debug"]
+            genus["pages"] = []
+
+            for extracted_text in debug_info["texts"]:
+                logger.info(f"Processing genus text: {extracted_text}")
+                processed_line = self.process_text(extracted_text, LineType.GENUS)
+
+                debug_info["message"] = "genus"
+                debug_info["need_verification"] = processed_line["need_verification"]
+
+                if processed_line["type"] == LineType.GENUS:
+                    genus["genus"] = processed_line["value"]
+                    genus["synonym"] = processed_line["synonym"]
+                    genus["matched_species"] = None
+                    genus["pages"] = processed_line["pages"]
+
+                    self.verify_species(genus["genus"], genus)
+
+                elif processed_line["type"] == LineType.CONTINUATION:
+                    debug_info["message"] = "genus_continuation"
+                    genus["pages"].extend(processed_line["pages"])
+
+                elif processed_line["type"] == LineType.GENUS_SYNONYM:
+                    debug_info["message"] = "genus_synonym"
+                    genus["synonym"] = processed_line["synonym"]
+
+                else:
+                    logger.warning(f"\t\tLine is not a genus: {processed_line['text']}")
+                    debug_info["message"] = "invalid genus line"
+
+            current_genus_synonym = None
+
+            for species in genus["species"]:
+                debug_info: DebugDict = species["debug"]
+                species["pages"] = []
+
+                for extracted_text in debug_info["texts"]:
+                    logger.info(f"\tProcessing species text: {extracted_text}")
+                    processed_line = self.process_text(extracted_text, LineType.SPECIES)
+
+                    debug_info["message"] = "species"
+                    debug_info["need_verification"] = processed_line[
+                        "need_verification"
+                    ]
+
+                    if processed_line["type"] == LineType.SPECIES:
+                        species["species"] = processed_line["value"]
+                        species["matched_species"] = None
+                        species["pages"] = processed_line["pages"]
+                        species["genus_synonym"] = current_genus_synonym
+
+                        self.verify_species(
+                            f"{genus['genus']} {species['species']}", species
+                        )
+
+                    elif processed_line["type"] == LineType.CONTINUATION:
+                        species["pages"].extend(processed_line["pages"])
+
+                    elif processed_line["type"] == LineType.GENUS_SYNONYM:
+                        debug_info["message"] = "genus_synonym"
+                        current_genus_synonym = GenusSynonymDict(
+                            genus=processed_line["value"], debug=debug_info
+                        )
+
+                    else:
+                        logger.warning(
+                            f"\t\tLine is not a species: {processed_line['text']}"
+                        )
+                        debug_info["message"] = "invalid species line"
+
+        self.save_species()
+
+    def verify_species(self, name: str, species: Union[GenusDict, SpeciesDict]) -> None:
+        with subprocess.Popen(
+            ["gnverifier", "-f", "compact", name],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ) as gnverifier_proc:
+            if gnverifier_proc.stdout:
+                verified_species = json.loads(gnverifier_proc.stdout.read())
+                result = verified_species.get("bestResult")
+                if result:
+                    record_id = result.get("recordId")
+                    if record_id:
+                        species["matched_species"] = record_id
+                        self.species_verified[record_id] = result
+
+    def retry_missing_verifications(self):
+        self.load_species()
+
+        total_processed = 0
+
+        for genus in self.species:
+            if not genus["matched_species"]:
+                logger.info(f"Verifying {genus['genus']}")
+                self.verify_species(genus["genus"], genus)
+                if genus["matched_species"]:
+                    total_processed += 1
+
+                for species in genus["species"]:
+                    if not species["matched_species"]:
+                        logger.info(f"Verifying {genus['genus']} {species['species']}")
+                        self.verify_species(
+                            f"{genus['genus']} {species['species']}", species
+                        )
+                        if species["matched_species"]:
+                            total_processed += 1
+
+        logger.info(f"Retried {total_processed} species.")
+
+        self.save_species()
+
+    def load_species(self):
+        if not (OUTPUT_PATH / "index_species.json").exists():
+            sys.exit(
+                "index_species.json does not exist. "
+                "Try running the script with --process."
+            )
+
+        with open(OUTPUT_PATH / "index_species.json", "r") as f:
+            self.species = json.load(f)["species"]
+
+    def save_species(self, save_errors=False):
+        for thread in self.species_verification_threads:
+            thread.join()
+
+        metadata = {
+            "gnverifier": self.gnverifier_version,
+            "date": str(datetime.datetime.now()),
+        }
+
+        with open(OUTPUT_PATH / "index_species.json", "w") as f:
+            json.dump({"metadata": metadata, "species": self.species}, f, indent=2)
+
+        with open(OUTPUT_PATH / "index_species_verified.json", "w") as f:
+            json.dump(
+                {"metadata": metadata, "species": self.species_verified}, f, indent=2
+            )
+
+        if save_errors:
+            with open(OUTPUT_PATH / "index_species_errors.json", "w") as f:
+                json.dump(self.unverified_lines, f, indent=2)
 
     def save_intermediate_images(
         self,
@@ -575,4 +808,14 @@ if __name__ == "__main__":
     if args.debug:
         logger.setLevel(logging.DEBUG)
 
-    SpeciesProcessor(args.debug).process()
+    if not args.process and not args.process_text and not args.verify_species:
+        parser.print_help()
+    else:
+        if args.process:
+            SpeciesProcessor(args.debug).process()
+
+        if args.process_text:
+            SpeciesProcessor(args.debug).retry_text_processing()
+
+        if args.verify_species:
+            SpeciesProcessor(args.debug).retry_missing_verifications()

--- a/workflows/update_stations.py
+++ b/workflows/update_stations.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List
 import fuzzysearch
 import numpy as np
 import pandas as pd
+from utils import check_gnames_app
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("HathiTrust")
@@ -123,7 +124,7 @@ RAMM_STATION_COLUMN_TYPES = {
     "Temp (F) at 2325 Fathoms": "float64",
     "Temp (F) at 2400 Fathoms": "float64",
     "Temp (F) at 2425 Fathoms": "float64",
-    "Temp (F) at 2400 Fathoms.1": "float64",
+    "Temp (F) at 2440 Fathoms": "float64",
     "Temp (F) at 2500 Fathoms": "float64",
     "Temp (F) at 2525 Fathoms": "float64",
     "Temp (F) at 2600 Fathoms": "float64",
@@ -137,55 +138,9 @@ RAMM_STATION_COLUMN_TYPES = {
 }
 
 
-def check_gnames_app(app_name: str, min_version: float) -> str:
-    """
-    Check if the given gnames app exists on the system
-    and its version is not less than min_version.
-    If the app does not exist terminate the process.
-    If the version is not satisfied, log a warning.
-
-    Parameters
-    ----------
-    app_name: names of a Global Names (gnames) app
-    min_version: minimum version required by the script
-
-    Returns
-    -------
-    version of the existing gnames app
-    """
-    try:
-        version_text = subprocess.run(
-            [app_name, "-V"], check=True, capture_output=True
-        ).stdout.decode("utf-8")
-        version = re.search(r"version: v(\d+).(\d+)", version_text)
-        if version:
-            version_number = float(f"{version.groups()[0]}.{version.groups()[1]}")
-            if version_number < min_version:
-                logger.warning(
-                    f"You have {app_name} version {version_number}. "
-                    f"The script is tested with {app_name} v{min_version}. "
-                    f"The calls to {app_name} might not work as expected."
-                )
-            return version_text.strip().split("\n")[0]
-        else:
-            sys.exit(
-                f"Could not get {app_name} version. "
-                f"The script is tested with {app_name} v{min_version}. "
-                "Make sure you have the right version on your system."
-            )
-
-    except FileNotFoundError:
-        sys.exit(f"{app_name} is missing")
-    except subprocess.CalledProcessError:
-        sys.exit(
-            f"The script is tested with {app_name} v{min_version}. "
-            "Make sure you have the right version on your system."
-        )
-
-
 def run() -> None:
     gnfinder_version = check_gnames_app("gnfinder", 0.16)
-    gnverifier_version = check_gnames_app("gnverifier", 0.5)
+    gnverifier_version = check_gnames_app("gnverifier", 0.6)
 
     # Load all columns as string, i.e. dtype="object"
     ramm_stations = pd.read_csv(WORK_DIR / "RAMM" / "stations.csv", dtype="object")
@@ -347,8 +302,7 @@ def run() -> None:
         for species in station_species:
             if species["name"] not in all_species_by_name:
                 with subprocess.Popen(
-                    # -s "9" uses World Register of Marine Species
-                    ["gnverifier", "-f", "compact", species["name"]],
+                    ["gnverifier", "-f", "compact", "-s", "9", species["name"]],
                     stdout=subprocess.PIPE,
                 ) as gnverifier_proc:
                     if gnverifier_proc.stdout:

--- a/workflows/utils.py
+++ b/workflows/utils.py
@@ -1,0 +1,52 @@
+import logging
+import re
+import subprocess
+import sys
+
+logger = logging.getLogger("Utils")
+
+
+def check_gnames_app(app_name: str, min_version: float) -> str:
+    """
+    Check if the given gnames app exists on the system
+    and its version is not less than min_version.
+    If the app does not exist terminate the process.
+    If the version is not satisfied, log a warning.
+
+    Parameters
+    ----------
+    app_name: names of a Global Names (gnames) app
+    min_version: minimum version required by the script
+
+    Returns
+    -------
+    version of the existing gnames app
+    """
+    try:
+        version_text = subprocess.run(
+            [app_name, "-V"], check=True, capture_output=True
+        ).stdout.decode("utf-8")
+        version = re.search(r"version: v(\d+).(\d+)", version_text)
+        if version:
+            version_number = float(f"{version.groups()[0]}.{version.groups()[1]}")
+            if version_number < min_version:
+                logger.warning(
+                    f"You have {app_name} version {version_number}. "
+                    f"The script is tested with {app_name} v{min_version}. "
+                    f"The calls to {app_name} might not work as expected."
+                )
+            return version_text.strip().split("\n")[0]
+        else:
+            sys.exit(
+                f"Could not get {app_name} version. "
+                f"The script is tested with {app_name} v{min_version}. "
+                "Make sure you have the right version on your system."
+            )
+
+    except FileNotFoundError:
+        sys.exit(f"{app_name} is missing")
+    except subprocess.CalledProcessError:
+        sys.exit(
+            f"The script is tested with {app_name} v{min_version}. "
+            "Make sure you have the right version on your system."
+        )


### PR DESCRIPTION
The update data is pushed to `data`. You can get the latest changes from that repo and browse them (see https://github.com/Oceans-1876/challenger-data/commit/c7b335736c053ccc7d839f66e79d6eaa8249d5a2).

`get_all_species.py` script now requires args to run different tasks. Run `python get_all_species.py --help` to see the flags:
- `--process`: runs the whole workflow (image processing, OCR, verification)
- `--process-text`: runs text processing and verification on data from existing `index_species.json`
- `--verify-species`: runs verification on data from existing `index_species.json`

Resolves #26.